### PR TITLE
Unexpected behavior when the vTicker is paused and the mouseenter mouseout gets executed.

### DIFF
--- a/jquery.vticker.js
+++ b/jquery.vticker.js
@@ -168,10 +168,10 @@
         el.bind("mouseenter", function () {
           //if the automatic scroll is paused, don't change that.
           if (state.isPaused == true) return; 
-
+          
           state.pausedByCode = true; 
 
-            // stop interval
+          // stop interval
           internal.stopInterval.call( initThis );
           methods.pause.call( initThis, true );
         }).bind("mouseleave", function () {
@@ -179,13 +179,47 @@
           if (state.isPaused == true && !state.pausedByCode) return;
             
           state.pausedByCode = false; 
-
+          
           methods.pause.call(initThis, false);
           // restart interval
           internal.startInterval.call( initThis );
         });
       }
     },
+
+    refresh: function(){
+        var state = $(this).data('state');
+        var options = state.options;
+        var el = $(this);
+        state.itemCount = el.children('ul').children('li').length;
+
+        el.css({ overflow: 'hidden', position: 'relative' })
+        .children('ul').css({ position: 'absolute', margin: 0, padding: 0 })
+        .children('li').css({ margin: options.margin, padding: options.padding });
+
+        if (isNaN(options.height) || options.height == 0) {
+            el.children('ul').children('li').each(function () {
+                var current = $(this);
+                if (current.height() > state.itemHeight)
+                    state.itemHeight = current.height();
+            });
+
+            // set the same height on all child elements
+            el.children('ul').children('li').each(function () {
+                var current = $(this);
+                current.height(state.itemHeight);
+            });
+
+            // set element to total height
+            var box = (options.margin) + (options.padding * 2);
+            el.height(((state.itemHeight + box) * options.showItems) + options.margin);
+        }
+        else {
+            // set the preferred height
+            el.height(options.height);
+        }
+
+    }, 
 
     pause: function(pauseState) {
       var state = $(this).data('state');


### PR DESCRIPTION
So, im changing this behavior cause in my opinion it's not the expected one. I look forward to hear what you think about it and discuss further more.
How its working right now:
-Initialize a vTicker.
-send a vTicker("pause", true)
-if the user mouses over the vTicker it's going to start scrolling again and the pause is set to false.

What i did with this pull request:
if the "pause" is set via code, then when the user mouses over the vTicker the event is discarded, so that the vTicker does not activate itself automatically.

I think this is how it should work and what's being expected, cause if i pause the ticker via code it should have effect on all the parameters of the ticker.

What do you think?
